### PR TITLE
Hotfix 24 7 2021

### DIFF
--- a/api/general/organizations/configure/networks.go
+++ b/api/general/organizations/configure/networks.go
@@ -21,6 +21,15 @@ type Network struct {
 	EnrollmentString string   `json:"enrollmentString"`
 }
 
+type CreateNetwork struct {
+	Name             string   `json:"name"`
+	ProductTypes     []string `json:"productTypes"`
+	Tags             []string `json:"tags"`
+	TimeZone         string   `json:"timeZone"`
+	CopyFromNetworkId   string   `json:"copyFromNetworkId"`
+	Notes   string   `json:"notes"`
+}
+
 type Clients []struct {
 	Usage struct {
 		Sent int `json:"sent"`
@@ -89,7 +98,7 @@ func PostNetworks(organizationId string, data interface{}) []api.Results {
 	baseurl := fmt.Sprintf("/organizations/%s/networks",
 		organizationId)
 	payload := user_agent.MarshalJSON(data)
-	var datamodel = Networks{}
+	var datamodel = CreateNetwork{}
 	sessions, err := api.Sessions(baseurl, "POST", payload, nil, datamodel)
 	if err != nil {
 		log.Fatal(err)

--- a/api/general/organizations/configure/organization.go
+++ b/api/general/organizations/configure/organization.go
@@ -17,7 +17,7 @@ type Organizations []struct {
 	Organization
 }
 
-type Claim struct {
+type ClaimDevicesLicensesAndOrders struct {
 	Orders   []string `json:"orders"`
 	Serials  []string `json:"serials"`
 	Licenses []struct {
@@ -100,10 +100,10 @@ func DelOrganization(organizationId string) []api.Results {
 // When claiming by order, all devices and licenses in the order will be
 // claimed; licenses will be added to the organization and devices will
 // be placed in the organization's inventory.
-func PostClaim(organizationId string, data interface{}) []api.Results {
+func PostClaimDevicesLicensesAndOrders(organizationId string, data interface{}) []api.Results {
 	baseurl := fmt.Sprintf("/organizations/%s/claim",  organizationId)
 	payload := user_agent.MarshalJSON(data)
-	var datamodel = Claim{}
+	var datamodel = ClaimDevicesLicensesAndOrders{}
 	sessions, err := api.Sessions(baseurl, "POST", payload, nil, datamodel)
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
# Description
renamed PostClaim to PostClaimDevicesLicensesAndOrders
CreateNetwork struct for PostNetwork API call. Main drive for this change is adding the missing "copyFromNetworkId" field in the body.

Fixes # (issue)
ClaimNetworks stuct updated 
renamed PostClaimDevicesLicensesAndOrders

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [X] Verified API body headers

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented on my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules